### PR TITLE
feat: implement Module 4 code signing enrichment

### DIFF
--- a/src/macollect/modules/code_signing.py
+++ b/src/macollect/modules/code_signing.py
@@ -1,0 +1,97 @@
+import subprocess
+import re
+from pathlib import Path
+
+class CodeSigning():
+
+    depends_on = ['persistence', 'processes']
+
+    def __init__(self, binaries: list):
+        self.binaries = binaries
+
+    def collect(self) -> dict:
+        signing = []
+        for binary in self.binaries:
+            entry = self._check_codesign(binary)
+            signing.append(entry)
+        flags = self._evaluate_flags(signing)
+        return {
+            'data': {'signing': signing},
+            'flags': flags
+        }
+
+    def _evaluate_flags(self, signing: list) -> list:
+        flags = []
+        trusted_prefixes = ('/usr/', '/System/', '/sbin/', '/bin/')
+        for entry in signing:
+            #initially, wanted to flag when signing identity does not match
+            #expected developer for known application name, but decided outside
+            #of v1 scope due to having to build and maintain a known_ids dict
+            if entry['signing_status'] in ['unsigned', 'adhoc']:
+                if entry['signing_status'] == 'unsigned':
+                    if entry['path'].startswith(trusted_prefixes):
+                        continue
+                    reason = 'Unsigned binary'
+                else:
+                    reason = 'Ad-hoc signed binary in persistence location'
+                flags.append({
+                    'type': entry['signing_status'],
+                    'source': entry['path'],
+                    'detail': ', '.join(entry['authority']) if entry['authority'] else '',
+                    'reason': reason
+                    })
+        return flags
+
+
+
+    def _check_codesign(self, path: str) -> dict:
+        signing = {
+            'path': path,
+            'identifier': '',
+            'format': '',
+            'team_id': '',
+            'authority': [],
+            'codesign_flags': '',
+            'notarization_ticket': False,
+            'signing_status': '',
+        }
+        try:
+            result = subprocess.run(
+                ['codesign', '-dvvv', path],
+                capture_output=True, text=True, timeout=10
+            )
+            output = result.stderr
+            signing['signing_status'] = self._derive_signing_status(output)
+            id_match = re.search(r'^Identifier=(.+)$', output, re.MULTILINE)
+            if id_match:
+                signing['identifier'] = id_match.group(1).strip()
+            format_match = re.search(r'^Format=(.+)$', output, re.MULTILINE)
+            if format_match:
+                signing['format'] = format_match.group(1).strip()
+            team_match = re.search(r'^TeamIdentifier=(.+)$', output, re.MULTILINE)
+            if team_match:
+                signing['team_id'] = team_match.group(1).strip()
+                if signing['team_id'] == 'not set':
+                    signing['team_id'] = ''
+            flags_match = re.search(r'flags=(\S+)', output)
+            if flags_match:
+                signing['codesign_flags'] = flags_match.group(1).strip()
+            signing['authority'] = re.findall(r'^Authority=(.+)$', output, re.MULTILINE)
+            signing['notarization_ticket'] = 'Notarization Ticket=stapled' in output
+        except subprocess.TimeoutExpired:
+            signing['signing_status'] = 'timeout'
+        except Exception as e:
+            signing['signing_status'] = f'error: {e}'
+        return signing
+
+
+    def _derive_signing_status(self, output: str) -> str:
+        if 'code object is not signed at all' in output:
+            return 'unsigned'
+        if 'flags=0x2(adhoc)' in output:
+            return 'adhoc'
+        if any('Software Signing' in line for line in output.splitlines()):
+            return 'apple_platform'
+        if any('Developer ID' in line for line in output.splitlines()):
+            return 'third_party'
+        return 'unknown'

--- a/src/macollect/modules/persistence.py
+++ b/src/macollect/modules/persistence.py
@@ -5,6 +5,8 @@ import itertools
 
 
 class Persistence():
+
+    depends_on = []
     
     def collect(self) -> dict:
         persistence = {}
@@ -51,6 +53,7 @@ class Persistence():
                 flags.append({
                     'type' : 'empty_label',
                     'source' : entry['source'],
+                    'detail' : '',
                     'reason' :  'Missing or empty label field in plist'
                 })
         for source, content in persistence['sudoers'].items():

--- a/src/macollect/modules/process_snapshot.py
+++ b/src/macollect/modules/process_snapshot.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 class ProcessSnapshot():
 
+    depends_on = []
+
     def collect(self) -> dict:
         processes = self._collect_processes()
         flags = self._evaluate_flags(processes)

--- a/src/macollect/modules/system_baseline.py
+++ b/src/macollect/modules/system_baseline.py
@@ -5,6 +5,8 @@ import re
 
 class SystemBaseline():
 
+    depends_on = []
+
     def collect(self) -> dict:
         baseline = {}
         baseline['hostname'] = gethostname()

--- a/src/macollect/pipeline.py
+++ b/src/macollect/pipeline.py
@@ -2,6 +2,7 @@ from macollect.report import ReportBuilder
 from macollect.modules.system_baseline import SystemBaseline
 from macollect.modules.persistence import Persistence
 from macollect.modules.process_snapshot import ProcessSnapshot
+from macollect.modules.code_signing import CodeSigning
 
 class MacollectPipeline:
     
@@ -11,7 +12,7 @@ class MacollectPipeline:
             'baseline': SystemBaseline,
             'persistence': Persistence,
              'processes': ProcessSnapshot,
-            # 'signing': CodeSigning,
+             'signing': CodeSigning,
             # 'tcc': TCCDatabases,
             # 'xattr': ExtendedAttributes,
             # 'credentials': CredentialArtifacts,
@@ -24,11 +25,26 @@ class MacollectPipeline:
         errors = []
         results = {}
         if not self.modules:
-            self.modules = ['baseline', 'persistence', 'processes',]# 'signing', 'tcc',
+            self.modules = ['baseline', 'persistence', 'processes', 'signing']#, 'tcc',
                 #'xattr', 'credentials','logs']
-        for name in self.modules:
+        modules_to_run = self._resolve_modules(self.modules)
+        for name in modules_to_run:
             module_class = self.registry[name]
-            module = module_class()
+            if name == 'signing':
+                binaries = []
+                persistence_data = results.get('persistence', {}).get('data', {})
+                process_flags = results.get('processes', {}).get('flags', [])
+                for entry in persistence_data.get('launch_daemons', []) + persistence_data.get('launch_agents', []):
+                    if entry.get('program'):
+                        binaries.append(entry['program'])
+                    elif entry.get('program_arguments'):
+                        binaries.append(entry['program_arguments'][0])
+                for entry in process_flags:
+                    binaries.append(entry['source'])
+                binaries = list(set(binaries))
+                module = module_class(binaries=binaries)
+            else:    
+                module = module_class()
             try:
                 results[name] = module.collect()
             except Exception as e:
@@ -38,3 +54,15 @@ class MacollectPipeline:
         report_builder = ReportBuilder()
         report = report_builder.build(results)
         return report
+    
+    def _resolve_modules(self, modules: list) -> list:
+        modules_to_run = []
+        for m in modules:
+            m_class = self.registry[m]
+            for dependency in m_class.depends_on:
+                if dependency not in modules_to_run:
+                    modules_to_run.append(dependency)
+            if m not in modules_to_run:
+                modules_to_run.append(m)
+        return modules_to_run
+


### PR DESCRIPTION
Implements Module 4 code signing enrichment.

Collection:
- Runs codesign -dvvv against all persistence binaries and flagged process binaries
- Per-binary fields: path, identifier, format, team_id, authority, codesign_flags, notarization_ticket, signing_status
- spctl dropped in favor of codesign-only approach — avoids network calls, maintains zero-dependency and enterprise deployability

Signing status classification:
- apple_platform: Authority chain contains Software Signing
- third_party: Authority chain contains Developer ID
- adhoc: flags field contains 0x2(adhoc)
- unsigned: codesign reports code object is not signed at all
- unknown: valid binary but unclassified
- timeout / error: collection failure cases

Flag logic:
- Unsigned binary outside trusted system paths
- Ad-hoc signed binary in persistence location
- Signing identity mismatch not implemented — requires known_ids dict, deferred

Dependency injection:
- depends_on = ['persistence', 'processes']
- Pipeline resolves dependencies automatically via _resolve_modules()
- Binary list extracted from persistence data and flagged process sources