### PR TITLE
feat(tcc): add Module 5 TCC database collection and flag logic

### DIFF
--- a/src/macollect/modules/tcc_databases.py
+++ b/src/macollect/modules/tcc_databases.py
@@ -1,0 +1,83 @@
+import sqlite3
+from pathlib import Path
+
+class TCCDatabases():
+
+    depends_on = []
+
+    def collect(self) -> dict:
+        
+        tcc = []
+        system_db = Path('/Library/Application Support/com.apple.TCC/TCC.db')
+        user_dbs = Path('/Users/').glob('*/Library/Application Support/com.apple.TCC/TCC.db')
+        if system_db.exists():
+            tcc.extend(self._parse_tcc(system_db, scope='system'))
+        for path in user_dbs:
+            user = path.parts[2]
+            tcc.extend(self._parse_tcc(path, scope=user))
+        flags = self._evaluate_flags(tcc)
+        return {
+            'data': {'tcc_entries': tcc},
+            'flags': flags
+            }
+
+    def _parse_tcc(self, path: Path, scope: str) -> list:
+       
+        tcc = []
+        try:
+            conn = sqlite3.connect(f'file:{path}?mode=ro', uri=True)
+            conn.row_factory = sqlite3.Row
+            cursor = conn.cursor()
+            cursor.execute("SELECT service, client, auth_value, last_modified FROM access")
+            for row in cursor.fetchall():
+                entry = dict(row)
+                entry['source'] = str(path)
+                entry['scope'] = scope
+                tcc.append(entry)
+            conn.close()
+        except sqlite3.OperationalError as e:
+            tcc.append({
+                'error': str(e),
+                'source': str(path),
+                'scope': scope,
+                'reason': 'FDA not granted or database inaccessible'
+                })
+        except Exception:
+            pass
+        return tcc
+
+    def _evaluate_flags(self, tcc: list) -> list:
+       
+        flags = []
+        sensitive_services = {
+            'kTCCServiceSystemPolicyAllFiles',
+            'kTCCServiceCamera',
+            'kTCCServiceMicrophone',
+            'kTCCServiceAddressBook',
+            'kTCCServiceCalendar',
+            'kTCCServiceScreenCapture',
+            'kTCCServiceAccessibility',
+            'kTCCServiceLocation',
+            'kTCCServiceDeveloperTool',
+            }
+        for entry in tcc:
+            if 'error' in entry:
+                continue
+            service = entry.get('service')
+            client = entry.get('client', '')
+            if service in sensitive_services:
+                if entry.get('auth_value') == 2:
+                    flags.append({
+                        'type': 'tcc_sensitive_grant',
+                        'source': entry['source'],
+                        'detail': f'client={client} service={service} auth_value={entry["auth_value"]} scope={entry["scope"]}',
+                        'reason': 'Explicit TCC grant for sensitive service — verify client is expected'
+                        })
+                if client.startswith('/'):
+                    flags.append({
+                        'type': 'tcc_path_based_client',
+                        'source': entry['source'],
+                        'detail': f'client={client} service={service} auth_value={entry["auth_value"]} scope={entry["scope"]}',
+                        'reason': 'Path-based TCC client on sensitive service — cannot be revoked by bundle ID, harder to attribute'
+                        })
+        return flags

--- a/src/macollect/pipeline.py
+++ b/src/macollect/pipeline.py
@@ -3,6 +3,7 @@ from macollect.modules.system_baseline import SystemBaseline
 from macollect.modules.persistence import Persistence
 from macollect.modules.process_snapshot import ProcessSnapshot
 from macollect.modules.code_signing import CodeSigning
+from macollect.modules.tcc_databases import TCCDatabases
 
 class MacollectPipeline:
     
@@ -13,7 +14,7 @@ class MacollectPipeline:
             'persistence': Persistence,
              'processes': ProcessSnapshot,
              'signing': CodeSigning,
-            # 'tcc': TCCDatabases,
+             'tcc': TCCDatabases,
             # 'xattr': ExtendedAttributes,
             # 'credentials': CredentialArtifacts,
             # 'logs': UnifiedLog
@@ -25,7 +26,7 @@ class MacollectPipeline:
         errors = []
         results = {}
         if not self.modules:
-            self.modules = ['baseline', 'persistence', 'processes', 'signing']#, 'tcc',
+            self.modules = ['baseline', 'persistence', 'processes', 'signing', 'tcc',]
                 #'xattr', 'credentials','logs']
         modules_to_run = self._resolve_modules(self.modules)
         for name in modules_to_run:

--- a/src/macollect/report.py
+++ b/src/macollect/report.py
@@ -20,6 +20,7 @@ class ReportBuilder:
         signing_data = results.get('signing', {}).get('data', {})
         signing_flags = results.get('signing', {}).get('flags', [])
         tcc_data = results.get('tcc', {}).get('data', {})
+        tcc_flags = results.get('tcc', {}).get('flags', {})
         xattr_data = results.get('xattr', {}).get('data', {})
         credentials_data = results.get('credentials', {}).get('data', {})
         logs_data = results.get('logs', {}).get('data', {})
@@ -50,7 +51,7 @@ class ReportBuilder:
             },
             'tcc_databases': {
                 'data': tcc_data,
-                'flags': []
+                'flags': tcc_flags
             },
             'extended_attributes': {
                 'data': xattr_data,


### PR DESCRIPTION
- Parses system and per-user TCC.db via read-only SQLite connection
- Flags sensitive service grants (auth_value=2) across high-value TCC services
- Flags path-based clients on sensitive services regardless of auth outcome
- Graceful degradation on FDA not granted — error logged, module does not drop