### PR TITLE
feat: add Module 6 extended attributes collection; refactor pipeline dependency injection to data-driven inject pattern

### DIFF
--- a/src/macollect/modules/code_signing.py
+++ b/src/macollect/modules/code_signing.py
@@ -2,12 +2,29 @@ import subprocess
 import re
 from pathlib import Path
 
+
 class CodeSigning():
 
     depends_on = ['persistence', 'processes']
+    inject = {
+        'persistence_data': ('persistence', 'data'),
+        'process_flags':    ('processes', 'flags'),
+        }
 
-    def __init__(self, binaries: list):
-        self.binaries = binaries
+    def __init__(self, persistence_data: dict = None, process_flags: list = None):
+        persistence_data = persistence_data or {}
+        process_flags = process_flags or []
+        binaries = []
+        for entry in persistence_data.get('launch_daemons', []) + persistence_data.get('launch_agents', []):
+            if isinstance(entry, dict):
+                if entry.get('program'):
+                    binaries.append(entry['program'])
+                elif entry.get('program_arguments'):
+                    binaries.append(entry['program_arguments'][0])
+        for entry in process_flags:
+            if entry.get('source'):
+                binaries.append(entry['source'])
+        self.binaries = list(set(binaries))
 
     def collect(self) -> dict:
         signing = []
@@ -18,15 +35,12 @@ class CodeSigning():
         return {
             'data': {'signing': signing},
             'flags': flags
-        }
+            }
 
     def _evaluate_flags(self, signing: list) -> list:
         flags = []
         trusted_prefixes = ('/usr/', '/System/', '/sbin/', '/bin/')
         for entry in signing:
-            #initially, wanted to flag when signing identity does not match
-            #expected developer for known application name, but decided outside
-            #of v1 scope due to having to build and maintain a known_ids dict
             if entry['signing_status'] in ['unsigned', 'adhoc']:
                 if entry['signing_status'] == 'unsigned':
                     if entry['path'].startswith(trusted_prefixes):
@@ -42,8 +56,6 @@ class CodeSigning():
                     })
         return flags
 
-
-
     def _check_codesign(self, path: str) -> dict:
         signing = {
             'path': path,
@@ -54,7 +66,7 @@ class CodeSigning():
             'codesign_flags': '',
             'notarization_ticket': False,
             'signing_status': '',
-        }
+            }
         try:
             result = subprocess.run(
                 ['codesign', '-dvvv', path],
@@ -83,7 +95,6 @@ class CodeSigning():
         except Exception as e:
             signing['signing_status'] = f'error: {e}'
         return signing
-
 
     def _derive_signing_status(self, output: str) -> str:
         if 'code object is not signed at all' in output:

--- a/src/macollect/modules/extended_attributes.py
+++ b/src/macollect/modules/extended_attributes.py
@@ -1,0 +1,98 @@
+import subprocess
+import itertools
+from pathlib import Path
+
+
+class ExtendedAttributes():
+
+    depends_on = ['persistence']
+    inject = {
+        'persistence_data': ('persistence', 'data'),
+        }
+
+    def __init__(self, persistence_data: dict = None):
+        self.persistence_data = persistence_data or {}
+
+    def collect(self) -> dict:
+        binaries = self._build_binary_list()
+        xattr_entries = []
+        for path in binaries:
+            entry = self._collect_xattrs(path)
+            if entry:
+                xattr_entries.append(entry)
+        flags = self._evaluate_flags(xattr_entries)
+        return {
+            'data': {'xattr_entries': xattr_entries},
+            'flags': flags
+            }
+
+    def _build_binary_list(self) -> list:
+        binaries = []
+        for entry in self.persistence_data.get('launch_daemons', []) + self.persistence_data.get('launch_agents', []):
+            if isinstance(entry, dict):
+                if entry.get('program'):
+                    binaries.append(entry['program'])
+                elif entry.get('program_arguments'):
+                    binaries.append(entry['program_arguments'][0])
+        abused_paths = itertools.chain(
+            Path('/tmp').glob('*'),
+            Path('/var/tmp').glob('*'),
+            Path('/Users/').glob('*/Downloads/*'),
+            Path('/Users/').glob('*/Desktop/*'),
+            )
+        for path in abused_paths:
+            if path.is_file():
+                binaries.append(str(path))
+        return list(set(binaries))
+
+    def _collect_xattrs(self, path: str) -> dict | None:
+        try:
+            result = subprocess.run(
+                ['xattr', '-l', path],
+                capture_output=True, text=True, timeout=10
+                )
+            if not result.stdout.strip():
+                return None
+            entry = {
+                'source': path,
+                'quarantine': '',
+                'where_froms': [],
+                'other': []
+                }
+            lines = result.stdout.splitlines()
+            for i, line in enumerate(lines):
+                if 'com.apple.quarantine' in line and ':' in line:
+                    entry['quarantine'] = line.split(':', 1)[-1].strip()
+                elif 'kMDItemWhereFroms' in line:
+                    entry['where_froms'] = line.split(':', 1)[-1].strip()
+                elif line and not line.startswith(' ') and ':' in line:
+                    attr_name = line.split(':')[0].strip()
+                    if attr_name not in (
+                        'com.apple.quarantine',
+                        'com.apple.metadata.kMDItemWhereFroms'
+                        ):
+                        entry['other'].append(attr_name)
+            return entry
+        except subprocess.TimeoutExpired:
+            return None
+        except Exception:
+            return None
+
+    def _evaluate_flags(self, xattr_entries: list) -> list:
+        flags = []
+        for entry in xattr_entries:
+            if entry.get('where_froms'):
+                flags.append({
+                    'type': 'downloaded_binary',
+                    'source': entry['source'],
+                    'detail': f'where_froms={entry["where_froms"]}',
+                    'reason': 'Binary in persistence or abused path has download provenance — verify source URL'
+                    })
+            if entry.get('quarantine'):
+                flags.append({
+                    'type': 'quarantined_binary',
+                    'source': entry['source'],
+                    'detail': f'quarantine={entry["quarantine"]}',
+                    'reason': 'Binary carries quarantine attribute — records originating application and download timestamp'
+                    })
+        return flags

--- a/src/macollect/modules/persistence.py
+++ b/src/macollect/modules/persistence.py
@@ -7,6 +7,7 @@ import itertools
 class Persistence():
 
     depends_on = []
+    inject = {}
     
     def collect(self) -> dict:
         persistence = {}
@@ -101,7 +102,8 @@ class Persistence():
                     entry['run_at_load'] = content.get('RunAtLoad', False)
                     entry['keep_alive'] = content.get('KeepAlive', False)
                     entry['username'] = content.get('UserName', '')
-                    entry['disabled'] = content.get('Disabled', False)
+                    disabled = content.get('Disabled', False)
+                    entry['disabled'] = bool(disabled) if isinstance(disabled, dict) else disabled
                     entry['environment_variables'] = content.get('EnvironmentVariables', {})
                     # Skip configuration-only plists (no Label or Program — e.g. jetsam memory config)
                     if not entry['label'] and not entry['program'] and not entry['program_arguments']:
@@ -137,7 +139,8 @@ class Persistence():
                     entry['run_at_load'] = content.get('RunAtLoad', False)
                     entry['keep_alive'] = content.get('KeepAlive', False)
                     entry['username'] = user
-                    entry['disabled'] = content.get('Disabled', False)
+                    disabled = content.get('Disabled', False)
+                    entry['disabled'] = bool(disabled) if isinstance(disabled, dict) else disabled
                     entry['environment_variables'] = content.get('EnvironmentVariables', {})
                     # Skip configuration-only plists (no Label or Program — e.g. jetsam memory config)
                     if not entry['label'] and not entry['program'] and not entry['program_arguments']:

--- a/src/macollect/modules/process_snapshot.py
+++ b/src/macollect/modules/process_snapshot.py
@@ -7,6 +7,7 @@ from pathlib import Path
 class ProcessSnapshot():
 
     depends_on = []
+    inject = {}
 
     def collect(self) -> dict:
         processes = self._collect_processes()

--- a/src/macollect/modules/system_baseline.py
+++ b/src/macollect/modules/system_baseline.py
@@ -6,6 +6,7 @@ import re
 class SystemBaseline():
 
     depends_on = []
+    inject = {}
 
     def collect(self) -> dict:
         baseline = {}

--- a/src/macollect/modules/tcc_databases.py
+++ b/src/macollect/modules/tcc_databases.py
@@ -4,6 +4,7 @@ from pathlib import Path
 class TCCDatabases():
 
     depends_on = []
+    inject = {}
 
     def collect(self) -> dict:
         

--- a/src/macollect/pipeline.py
+++ b/src/macollect/pipeline.py
@@ -4,21 +4,22 @@ from macollect.modules.persistence import Persistence
 from macollect.modules.process_snapshot import ProcessSnapshot
 from macollect.modules.code_signing import CodeSigning
 from macollect.modules.tcc_databases import TCCDatabases
+from macollect.modules.extended_attributes import ExtendedAttributes
+
 
 class MacollectPipeline:
-    
+
     def __init__(self, modules: list, time_window: int = 24):
-        
         self.registry = {
-            'baseline': SystemBaseline,
+            'baseline':    SystemBaseline,
             'persistence': Persistence,
-             'processes': ProcessSnapshot,
-             'signing': CodeSigning,
-             'tcc': TCCDatabases,
-            # 'xattr': ExtendedAttributes,
+            'processes':   ProcessSnapshot,
+            'signing':     CodeSigning,
+            'tcc':         TCCDatabases,
+            'xattr':       ExtendedAttributes,
             # 'credentials': CredentialArtifacts,
-            # 'logs': UnifiedLog
-        }
+            # 'logs':        UnifiedLog
+            }
         self.modules = modules
         self.time_window = time_window
 
@@ -26,26 +27,13 @@ class MacollectPipeline:
         errors = []
         results = {}
         if not self.modules:
-            self.modules = ['baseline', 'persistence', 'processes', 'signing', 'tcc',]
-                #'xattr', 'credentials','logs']
+            self.modules = ['baseline', 'persistence', 'processes', 'signing', 'tcc', 'xattr',]
+                            #credentials, logs]
         modules_to_run = self._resolve_modules(self.modules)
         for name in modules_to_run:
             module_class = self.registry[name]
-            if name == 'signing':
-                binaries = []
-                persistence_data = results.get('persistence', {}).get('data', {})
-                process_flags = results.get('processes', {}).get('flags', [])
-                for entry in persistence_data.get('launch_daemons', []) + persistence_data.get('launch_agents', []):
-                    if entry.get('program'):
-                        binaries.append(entry['program'])
-                    elif entry.get('program_arguments'):
-                        binaries.append(entry['program_arguments'][0])
-                for entry in process_flags:
-                    binaries.append(entry['source'])
-                binaries = list(set(binaries))
-                module = module_class(binaries=binaries)
-            else:    
-                module = module_class()
+            kwargs = self._build_kwargs(module_class, results)
+            module = module_class(**kwargs)
             try:
                 results[name] = module.collect()
             except Exception as e:
@@ -55,7 +43,13 @@ class MacollectPipeline:
         report_builder = ReportBuilder()
         report = report_builder.build(results)
         return report
-    
+
+    def _build_kwargs(self, module_class, results: dict) -> dict:
+        kwargs = {}
+        for param, (module_name, key) in getattr(module_class, 'inject', {}).items():
+            kwargs[param] = results.get(module_name, {}).get(key, {})
+        return kwargs
+
     def _resolve_modules(self, modules: list) -> list:
         modules_to_run = []
         for m in modules:
@@ -66,4 +60,3 @@ class MacollectPipeline:
             if m not in modules_to_run:
                 modules_to_run.append(m)
         return modules_to_run
-

--- a/src/macollect/report.py
+++ b/src/macollect/report.py
@@ -20,8 +20,9 @@ class ReportBuilder:
         signing_data = results.get('signing', {}).get('data', {})
         signing_flags = results.get('signing', {}).get('flags', [])
         tcc_data = results.get('tcc', {}).get('data', {})
-        tcc_flags = results.get('tcc', {}).get('flags', {})
+        tcc_flags = results.get('tcc', {}).get('flags', [])
         xattr_data = results.get('xattr', {}).get('data', {})
+        xattr_flags = results.get('xattr', {}).get('flags', [])
         credentials_data = results.get('credentials', {}).get('data', {})
         logs_data = results.get('logs', {}).get('data', {})
         report['collection_metadata'] = {
@@ -55,7 +56,7 @@ class ReportBuilder:
             },
             'extended_attributes': {
                 'data': xattr_data,
-                'flags': []
+                'flags': xattr_flags
             },
             'credential_artifacts': {
                 'data': credentials_data,


### PR DESCRIPTION
feat: Module 6 extended attributes collection; refactor pipeline dependency injection to data-driven inject pattern

- Collects xattr data for persistence binaries and files in commonly abused paths (/tmp, /var/tmp, ~/Downloads, ~/Desktop)
- Captures com.apple.quarantine, com.apple.metadata.kMDItemWhereFroms, and any other attributes present
- Refactor: replace hardcoded signing binary extraction in pipeline.py with generic _build_kwargs() resolver
- Modules now declare inject class attribute to specify constructor dependencies
- CodeSigning binary list building moved from pipeline into CodeSigning.__init__
- Fix: normalize quarantine/where_froms to empty string/list instead of null
- Fix: disabled field type guard for conditional plist dicts