### PR TITLE
feat: implement Module 8 unified log collection

### DIFF
--- a/src/macollect/modules/credential_artifacts.py
+++ b/src/macollect/modules/credential_artifacts.py
@@ -1,4 +1,3 @@
-import subprocess
 from pathlib import Path
 
 

--- a/src/macollect/modules/unified_log.py
+++ b/src/macollect/modules/unified_log.py
@@ -1,0 +1,55 @@
+import subprocess
+from pathlib import Path
+
+
+class UnifiedLog():
+
+    depends_on = []
+    inject = {}
+
+    def __init__(self, time_window: int = 24):
+        self.time_window = time_window
+
+    def collect(self) -> dict:
+        subsystems = [
+            'com.apple.security',
+            'com.apple.xpc',
+            'com.apple.launchd',
+            'com.apple.backgroundtaskmanagement',
+            'com.apple.authorization',
+            'com.apple.authenticate',
+            ]
+        data = {}
+        for subsystem in subsystems:
+            data[subsystem] = self._collect_subsystem(subsystem)
+        flags = self._evaluate_flags(data)
+        return {
+            'data': data,
+            'flags': flags
+            }
+
+    def _collect_subsystem(self, subsystem: str) -> dict:
+        try:
+            result = subprocess.run(
+                    ['log', 'show',
+                    '--predicate', f'subsystem == "{subsystem}"',
+                    '--last', f'{self.time_window}h',
+                    '--level', 
+                    'error'
+                    ],
+                capture_output=True, text=True, timeout=60
+                )
+            lines = [l for l in result.stdout.splitlines() if l.strip()]
+            # first line is always the log header, skip it
+            entries = lines[1:] if len(lines) > 1 else []
+            return {
+                'event_count': len(entries),
+                'entries': entries[:25],
+                }
+        except subprocess.TimeoutExpired:
+            return {'event_count': 0, 'entries': [], 'error': 'timeout'}
+        except Exception as e:
+            return {'event_count': 0, 'entries': [], 'error': str(e)}
+
+    def _evaluate_flags(self, data: dict) -> list:
+        return []

--- a/src/macollect/pipeline.py
+++ b/src/macollect/pipeline.py
@@ -6,6 +6,7 @@ from macollect.modules.code_signing import CodeSigning
 from macollect.modules.tcc_databases import TCCDatabases
 from macollect.modules.extended_attributes import ExtendedAttributes
 from macollect.modules.credential_artifacts import CredentialArtifacts
+from macollect.modules.unified_log import UnifiedLog
 
 
 class MacollectPipeline:
@@ -19,7 +20,7 @@ class MacollectPipeline:
             'tcc':         TCCDatabases,
             'xattr':       ExtendedAttributes,
             'credentials': CredentialArtifacts,
-            # 'logs':        UnifiedLog
+             'logs':        UnifiedLog
             }
         self.modules = modules
         self.time_window = time_window
@@ -29,11 +30,13 @@ class MacollectPipeline:
         results = {}
         if not self.modules:
             self.modules = ['baseline', 'persistence', 'processes', 'signing', 'tcc', 'xattr',
-                            'credentials',] #'logs']
+                            'credentials', 'logs']
         modules_to_run = self._resolve_modules(self.modules)
         for name in modules_to_run:
             module_class = self.registry[name]
             kwargs = self._build_kwargs(module_class, results)
+            if name == 'logs':
+                kwargs['time_window'] = self.time_window
             module = module_class(**kwargs)
             try:
                 results[name] = module.collect()

--- a/src/macollect/report.py
+++ b/src/macollect/report.py
@@ -26,6 +26,7 @@ class ReportBuilder:
         credentials_data = results.get('credentials', {}).get('data', {})
         credentials_flags = results.get('credentials', {}).get('flags', [])
         logs_data = results.get('logs', {}).get('data', {})
+        logs_flags = results.get('logs', {}).get('flags', [])
         report['collection_metadata'] = {
             'macollect_version': VERSION,
             'collected_at': datetime.now().isoformat(),


### PR DESCRIPTION
feat: Module 8 unified log collection

- Shells out to log show filtered to security-relevant subsystems
- Subsystems: security, xpc, launchd, backgroundtaskmanagement, authorization, authenticate
- Configurable time window via CLI, defaults to 24 hours
- Output grouped per subsystem with event count and up to 25 representative entries
- Error-level filter applied globally to control output volume
- time_window injected manually in pipeline.run() as pipeline-level variable