### PR TITLE
fix: pre-release bug fixes, style cleanup, and detection tuning

### DIFF
--- a/src/macollect/cli.py
+++ b/src/macollect/cli.py
@@ -19,8 +19,8 @@ def parse_args() -> argparse.Namespace:
         epilog='https://github.com/ryoshu404/macollect',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument('-m', '--modules', nargs='+', choices=['baseline', 'persistence', 
-        'processes', 'signing', 'tcc', 'xattr', 'credentials','logs'], default=None, 
+    parser.add_argument('-m', '--modules', nargs='+', choices=['baseline', 'persistence',
+        'processes', 'signing', 'tcc', 'xattr', 'credentials','logs'], default=None,
         help='--modules: baseline persistence processes signing tcc xattr credentials logs')
     parser.add_argument('-f', '--format', choices=['json'], default='json', help='Output format')
     parser.add_argument('-t', '--time-window', type=int, default=24, help='Time window for ' \
@@ -39,6 +39,8 @@ def main():
     report = pipeline.run()
     match args.format:
         case 'json':
+            formatted = format_json(report)
+        case _:
             formatted = format_json(report)
     if args.output:
         output = Path(args.output).expanduser()

--- a/src/macollect/modules/credential_artifacts.py
+++ b/src/macollect/modules/credential_artifacts.py
@@ -108,6 +108,7 @@ class CredentialArtifacts():
                     keychains[str(path)] = {'error': 'stat failed'}
         return keychains
 
+    # identical to persistence._read_text_file, intentional, no shared utils module
     def _read_text_file(self, path: Path) -> tuple:
         try:
             with open(path, 'r') as f:

--- a/src/macollect/modules/extended_attributes.py
+++ b/src/macollect/modules/extended_attributes.py
@@ -64,7 +64,11 @@ class ExtendedAttributes():
                 if 'com.apple.quarantine' in line and ':' in line:
                     entry['quarantine'] = line.split(':', 1)[-1].strip()
                 elif 'kMDItemWhereFroms' in line:
-                    entry['where_froms'] = line.split(':', 1)[-1].strip()
+                    where_result = subprocess.run(
+                        ['xattr', '-p', 'com.apple.metadata.kMDItemWhereFroms', path],
+                        capture_output=True, text=True, timeout=10
+                    )
+                    entry['where_froms'] = where_result.stdout.strip()
                 elif line and not line.startswith(' ') and ':' in line:
                     attr_name = line.split(':')[0].strip()
                     if attr_name not in (

--- a/src/macollect/modules/persistence.py
+++ b/src/macollect/modules/persistence.py
@@ -8,7 +8,7 @@ class Persistence():
 
     depends_on = []
     inject = {}
-    
+
     def collect(self) -> dict:
         persistence = {}
         persistence['btm'] = self._collect_btm() or ''
@@ -19,15 +19,17 @@ class Persistence():
         persistence['shell_configs'] = self._collect_shell_configs() or {}
         persistence['sudoers'] = self._collect_sudoers() or {}
         persistence['cron'] = self._collect_cron() or {}
-        flags = self._evaluate_flag(persistence)
+        flags = self._evaluate_flags(persistence)
         return {
             'data': persistence,
             'flags': flags
             }
-    
-    def _evaluate_flag(self, persistence: dict) -> list:
+
+    def _evaluate_flags(self, persistence: dict) -> list:
         flags = []
         for entry in persistence['launch_daemons'] + persistence['launch_agents']:
+            if not isinstance(entry, dict):
+                continue
             if entry['program'] and entry['program'].startswith(('/tmp', '/var/tmp', '/Users/')):
                 flags.append({
                     'type': 'writable_path',
@@ -35,36 +37,36 @@ class Persistence():
                     'detail': entry['program'],
                     'reason': 'Persistence method runs from a writable location'
                 })
-            if entry['program'] and entry['program'].startswith('.'):
+            if entry['program'] and Path(entry['program']).name.startswith('.'):
                 flags.append({
-                    'type' : 'hidden_file',
+                    'type': 'hidden_file',
                     'source': entry['source'],
                     'detail': entry['program'],
                     'reason': 'Program key pointing to hidden file'
                 })
-            for arg in entry['program_arguments']:
+            for arg in entry['program_arguments'][0]:
                 if arg.startswith(('/tmp', '/var/tmp', '/Users/')):
                     flags.append({
-                        'type' : 'writable_path',
-                        'source' : entry['source'],
-                        'detail' : arg,
-                        'reason' : 'Persistence method runs from a writable location',
+                        'type': 'writable_path',
+                        'source': entry['source'],
+                        'detail': arg,
+                        'reason': 'Persistence method runs from a writable location',
                     })
             if not entry['label']:
                 flags.append({
-                    'type' : 'empty_label',
-                    'source' : entry['source'],
-                    'detail' : '',
-                    'reason' :  'Missing or empty label field in plist'
+                    'type': 'empty_label',
+                    'source': entry['source'],
+                    'detail': '',
+                    'reason': 'Missing or empty label field in plist'
                 })
         for source, content in persistence['sudoers'].items():
             for line in content.split('\n'):
                 if 'NOPASSWD' in line and not line.strip().startswith('#'):
                     flags.append({
-                        'type' : 'sudoers_unexpected_entry',
-                        'source' : source,
-                        'detail' : line,
-                        'reason' : 'NOPASSWD entry in sudoers'
+                        'type': 'sudoers_unexpected_entry',
+                        'source': source,
+                        'detail': line,
+                        'reason': 'NOPASSWD entry in sudoers'
                     })
         if persistence['loginwindow'].get('auto_login_user'):
             flags.append({
@@ -74,10 +76,10 @@ class Persistence():
                 'reason': 'Autologin is enabled'
             })
         return flags
-        
+
     def _collect_btm(self) -> str:
         try:
-            btm = subprocess.run(['sfltool', 'dumpbtm'], 
+            btm = subprocess.run(['sfltool', 'dumpbtm'],
                 capture_output=True, text=True, timeout=10).stdout.strip()
         except subprocess.TimeoutExpired:
             btm = ''
@@ -159,7 +161,7 @@ class Persistence():
         for path in paths:
             login_items.append(str(path))
         return login_items
-    
+
     def _collect_loginwindow(self) -> dict:
         login_window = {}
         source = '/Library/Preferences/com.apple.loginwindow.plist'
@@ -175,7 +177,7 @@ class Persistence():
         except Exception as e:
             login_window['error'] = f'Error: {e}, for {source}'
         return login_window
-    
+
     def _collect_shell_configs(self) -> dict:
         shell_configs = {}
         users = Path('/Users/').glob('*/')
@@ -190,7 +192,7 @@ class Persistence():
         for path in system_configs:
             if path.exists():
                 entry, content = self._read_text_file(path)
-                shell_configs[entry] = content                  
+                shell_configs[entry] = content
         return shell_configs
 
     def _collect_sudoers(self) -> dict:
@@ -218,19 +220,19 @@ class Persistence():
                 entry, content = self._read_text_file(path)
                 collect_cron[entry] = content
         try:
-            atq = subprocess.run(['atq'], 
+            atq = subprocess.run(['atq'],
                 capture_output=True, text=True, timeout=10).stdout.strip()
         except subprocess.TimeoutExpired:
             atq = ''
         collect_cron['atq'] = atq
         return collect_cron
-    
-    def _read_text_file(self, path: Path) -> dict:
+
+    # identical to credential_artifacts._read_text_file, intentional, no shared utils module
+    def _read_text_file(self, path: Path) -> tuple:
         try:
             with open(path, 'r') as f:
-                content = f.read()
-                return str(path), content
+                return str(path), f.read()
         except PermissionError:
             return str(path), f'PermissionError for {path}'
         except Exception as e:
-            return str(path), f'Error: {e}, for {path}' 
+            return str(path), f'Error: {e}, for {path}'

--- a/src/macollect/modules/process_snapshot.py
+++ b/src/macollect/modules/process_snapshot.py
@@ -34,12 +34,14 @@ class ProcessSnapshot():
                     })
             if entry['process_name'] and entry['comm']:
                 comm_name = Path(entry['comm']).name
-                if not entry['process_name'].startswith(comm_name):
-                    flags.append({
-                        'type': 'argv0_mismatch',
-                        'source': entry['binary_path'],
-                        'detail': f'pid={entry["pid"]} comm={entry["comm"]} argv0={entry["process_name"]}',
-                        'reason': 'Process name does not match argv[0] — possible masquerading'
+                process_name = Path(entry['process_name']).name
+                if comm_name != process_name:
+                    if not entry['binary_path'].startswith(('/usr/', '/System/', '/sbin/', '/bin/')):
+                        flags.append({
+                            'type': 'argv0_mismatch',
+                            'source': entry['binary_path'],
+                            'detail': f'pid={entry["pid"]} comm={entry["comm"]} argv0={entry["process_name"]}',
+                            'reason': 'Process name does not match argv[0] — possible masquerading'
                         })
             if entry['binary_path'] and entry['binary_path'].startswith(('/tmp', '/var/tmp', '/Users/')):
                 flags.append({
@@ -84,7 +86,6 @@ class ProcessSnapshot():
             return None
         except Exception:
             return None
-        return None
 
     def _collect_processes(self) -> list:
         processes = []

--- a/src/macollect/modules/system_baseline.py
+++ b/src/macollect/modules/system_baseline.py
@@ -17,6 +17,8 @@ class SystemBaseline():
             who = subprocess.run(['who'], capture_output=True, text=True, timeout=10)
             current_users = []
             for line in who.stdout.strip().split('\n'):
+                if not line.strip():
+                    continue
                 field = line.split()
                 current_users.append({
                     'username': field[0],
@@ -33,28 +35,28 @@ class SystemBaseline():
             baseline['uptime'] = match.group(1).strip() if match else ''
         except subprocess.TimeoutExpired:
             baseline['uptime'] = ''
-        try:    
-            baseline['macos_version'] = subprocess.run(['sw_vers', '-productVersion'], 
+        try:
+            baseline['macos_version'] = subprocess.run(['sw_vers', '-productVersion'],
                 capture_output=True, text=True, timeout=10).stdout.strip()
         except subprocess.TimeoutExpired:
             baseline['macos_version'] = ''
-        try:    
-            baseline['build_version'] = subprocess.run(['sw_vers', '-buildVersion'], 
+        try:
+            baseline['build_version'] = subprocess.run(['sw_vers', '-buildVersion'],
                 capture_output=True, text=True, timeout=10).stdout.strip()
         except subprocess.TimeoutExpired:
             baseline['build_version'] = ''
-        try:    
-            baseline['architecture'] = subprocess.run(['uname', '-m'], 
+        try:
+            baseline['architecture'] = subprocess.run(['uname', '-m'],
                 capture_output=True, text=True, timeout=10).stdout.strip()
         except subprocess.TimeoutExpired:
             baseline['architecture'] = ''
-        try:    
-            baseline['hardware_model'] = subprocess.run(['sysctl', '-n', 'hw.model'], 
+        try:
+            baseline['hardware_model'] = subprocess.run(['sysctl', '-n', 'hw.model'],
                 capture_output=True, text=True, timeout=10).stdout.strip()
         except subprocess.TimeoutExpired:
             baseline['hardware_model'] = ''
-        try:    
-            output = subprocess.run(['csrutil', 'status'], 
+        try:
+            output = subprocess.run(['csrutil', 'status'],
                 capture_output=True, text=True, timeout=10).stdout.strip()
             baseline['sip_status'] = 'enabled' if 'enabled' in output \
             else 'disabled' if 'disabled' in output else 'unknown'

--- a/src/macollect/modules/tcc_databases.py
+++ b/src/macollect/modules/tcc_databases.py
@@ -7,7 +7,7 @@ class TCCDatabases():
     inject = {}
 
     def collect(self) -> dict:
-        
+
         tcc = []
         system_db = Path('/Library/Application Support/com.apple.TCC/TCC.db')
         user_dbs = Path('/Users/').glob('*/Library/Application Support/com.apple.TCC/TCC.db')
@@ -23,7 +23,7 @@ class TCCDatabases():
             }
 
     def _parse_tcc(self, path: Path, scope: str) -> list:
-       
+
         tcc = []
         try:
             conn = sqlite3.connect(f'file:{path}?mode=ro', uri=True)
@@ -48,7 +48,7 @@ class TCCDatabases():
         return tcc
 
     def _evaluate_flags(self, tcc: list) -> list:
-       
+
         flags = []
         sensitive_services = {
             'kTCCServiceSystemPolicyAllFiles',

--- a/src/macollect/modules/unified_log.py
+++ b/src/macollect/modules/unified_log.py
@@ -33,13 +33,11 @@ class UnifiedLog():
             result = subprocess.run(
                     ['log', 'show',
                     '--predicate', f'subsystem == "{subsystem}"',
-                    '--last', f'{self.time_window}h',
-                    '--level', 
-                    'error'
+                    '--last', f'{self.time_window}h'
                     ],
                 capture_output=True, text=True, timeout=60
                 )
-            lines = [l for l in result.stdout.splitlines() if l.strip()]
+            lines = [line for line in result.stdout.splitlines() if line.strip()]
             # first line is always the log header, skip it
             entries = lines[1:] if len(lines) > 1 else []
             return {

--- a/src/macollect/pipeline.py
+++ b/src/macollect/pipeline.py
@@ -20,7 +20,7 @@ class MacollectPipeline:
             'tcc':         TCCDatabases,
             'xattr':       ExtendedAttributes,
             'credentials': CredentialArtifacts,
-             'logs':        UnifiedLog
+            'logs':        UnifiedLog
             }
         self.modules = modules
         self.time_window = time_window

--- a/src/macollect/report.py
+++ b/src/macollect/report.py
@@ -8,7 +8,7 @@ except importlib.metadata.PackageNotFoundError:
     VERSION = 'unknown'
 
 class ReportBuilder:
-    
+
     def build(self, results: dict) -> dict:
 
         report = {}
@@ -69,6 +69,6 @@ class ReportBuilder:
                 'flags': []
             }
         }
-        report['errors'] = []
+        report['errors'] = results.get('errors', [])
 
         return report


### PR DESCRIPTION
Bugs fixed:
- report.py: errors array hardcoded to [], now correctly reads from results
- persistence.py: TypeError on PermissionError string entries in _evaluate_flags, added isinstance guard
- persistence.py: hidden file check failed on absolute paths, now uses Path.name
- system_baseline.py: IndexError on empty who output, added empty line guard
- extended_attributes.py: kMDItemWhereFroms always empty:,switched to two-call xattr approach

Detection tuning:
- persistence.py: writable_path now checks program_arguments[0] only, fixes false positive on argument/output paths (kdumpd)
- process_snapshot.py: argv0_mismatch now compares basenames only and suppresses Apple system paths, reduces noise on legitimate macOS processes

Style:
- persistence.py: renamed _evaluate_flag to _evaluate_flags for consistency
- pipeline.py: removed extra leading space before 'logs' in registry
- unified_log.py: renamed loop variable l to line, removed --level error filter
- tcc_databases.py: stripped trailing whitespace on blank lines
- credential_artifacts.py / persistence.py: normalized _read_text_file, fixed return type annotation, added cross-reference comment
- cli.py: added case _: default to match block
- process_snapshot.py: removed dead return None at end of _get_responsible_pid