### PR TITLE
Fix/post release patch

### DIFF
--- a/src/macollect/modules/code_signing.py
+++ b/src/macollect/modules/code_signing.py
@@ -1,6 +1,6 @@
 import subprocess
 import re
-from pathlib import Path
+import os
 
 
 class CodeSigning():
@@ -26,16 +26,17 @@ class CodeSigning():
                 binaries.append(entry['source'])
         self.binaries = list(set(binaries))
 
-    def collect(self) -> dict:
-        signing = []
-        for binary in self.binaries:
-            entry = self._check_codesign(binary)
-            signing.append(entry)
-        flags = self._evaluate_flags(signing)
-        return {
-            'data': {'signing': signing},
-            'flags': flags
-            }
+def collect(self) -> dict:
+    signing = [
+        entry for entry in
+        (self._check_codesign(b) for b in self.binaries)
+        if entry is not None
+        ]
+    flags = self._evaluate_flags(signing)
+    return {
+        'data': {'signing': signing},
+        'flags': flags
+        }
 
     def _evaluate_flags(self, signing: list) -> list:
         flags = []
@@ -57,6 +58,8 @@ class CodeSigning():
         return flags
 
     def _check_codesign(self, path: str) -> dict:
+        if not os.path.isfile(path):
+            return None
         signing = {
             'path': path,
             'identifier': '',

--- a/src/macollect/modules/persistence.py
+++ b/src/macollect/modules/persistence.py
@@ -44,14 +44,14 @@ class Persistence():
                     'detail': entry['program'],
                     'reason': 'Program key pointing to hidden file'
                     })
-            for arg in entry['program_arguments'][0]:
-                if arg.startswith(('/tmp', '/var/tmp', '/Users/')):
-                    flags.append({
-                        'type': 'writable_path',
-                        'source': entry['source'],
-                        'detail': arg,
-                        'reason': 'Persistence method runs from a writable location',
-                        })
+            program_args = entry['program_arguments']
+            if program_args and program_args[0].startswith(('/tmp', '/var/tmp', '/Users/')):
+                flags.append({
+                    'type': 'writable_path',
+                    'source': entry['source'],
+                    'detail': program_args[0],
+                    'reason': 'Persistence method runs from a writable location',
+                })
             if not entry['label']:
                 flags.append({
                     'type': 'empty_label',

--- a/src/macollect/modules/unified_log.py
+++ b/src/macollect/modules/unified_log.py
@@ -1,5 +1,4 @@
 import subprocess
-from pathlib import Path
 
 
 class UnifiedLog():


### PR DESCRIPTION
- persistence.py: fix IndexError on empty program_arguments, [0] was being iterated over characters instead of checked as a string
- code_signing.py: filter non-file paths before codesign inspection: skips directories, relative paths, and non-binaries via os.path.isfile()
- code_signing.py: remove unused Path import